### PR TITLE
feat: add clipboard copy functionality for generated thumbnails

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -340,6 +340,26 @@ input[type="text"]::placeholder {
   height: 100%;
 }
 
+.btn-clipboard {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin: var(--spacing-sm) auto 0;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.btn-clipboard:hover {
+  color: var(--color-text);
+  border-color: var(--color-primary);
+}
+
 .preview-help {
   margin-top: var(--spacing-md);
   background: var(--color-surface);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -230,7 +230,7 @@ function App() {
   const generateSvg = useCallback(() => generateSvgRef.current(), [])
 
   // Export functionality
-  const { exportRaster, exportSvg } = useExport(generateSvg, resolution, showToast)
+  const { exportRaster, exportSvg, copyToClipboard } = useExport(generateSvg, resolution, showToast, fieldValues.title)
 
   const handleExportRaster = useCallback(() => {
     exportRaster(exportFormat)
@@ -461,6 +461,13 @@ function App() {
               onGenerateSvg={setGenerateSvg}
             />
           </div>
+          <button type="button" className="btn btn-clipboard" onClick={copyToClipboard} title="Copy to clipboard">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M3 10V2.5A1.5 1.5 0 0 1 4.5 1H10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            Copy to clipboard
+          </button>
 
           <aside className="preview-help" aria-label="Instructions">
             <h3 className="preview-help-title">Quick tips</h3>

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -78,7 +78,7 @@ export function useExport(generateSvg, resolution, showToast, title) {
             console.error('Export failed:', err)
             showToast('Export failed. Try SVG export instead.', 'error')
         }
-    }, [resolution, generateSvg, showToast])
+    }, [resolution, generateSvg, showToast, title])
 
     // Export as SVG
     const exportSvg = useCallback(() => {
@@ -91,13 +91,14 @@ export function useExport(generateSvg, resolution, showToast, title) {
         a.click()
         URL.revokeObjectURL(url)
         showToast('SVG exported successfully!')
-    }, [generateSvg, showToast])
+    }, [generateSvg, showToast, title])
 
     // Copy preview to clipboard as PNG
     const copyToClipboard = useCallback(async () => {
         const [width, height] = parseResolution(resolution)
         const svgString = generateSvg()
 
+        let url
         try {
             const inlinedSvg = await inlineSvgImages(svgString)
 
@@ -110,7 +111,7 @@ export function useExport(generateSvg, resolution, showToast, title) {
             const img = new Image()
             img.crossOrigin = 'anonymous'
             const svgBlob = new Blob([inlinedSvg], { type: 'image/svg+xml;charset=utf-8' })
-            const url = URL.createObjectURL(svgBlob)
+            url = URL.createObjectURL(svgBlob)
 
             await new Promise((resolve, reject) => {
                 img.onload = resolve
@@ -119,7 +120,6 @@ export function useExport(generateSvg, resolution, showToast, title) {
             })
 
             ctx.drawImage(img, 0, 0, width, height)
-            URL.revokeObjectURL(url)
 
             const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'))
             if (!blob) {
@@ -133,6 +133,8 @@ export function useExport(generateSvg, resolution, showToast, title) {
         } catch (err) {
             console.error('Copy to clipboard failed:', err)
             showToast('Failed to copy to clipboard.', 'error')
+        } finally {
+            if (url) URL.revokeObjectURL(url)
         }
     }, [resolution, generateSvg, showToast])
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -2,9 +2,21 @@ import { useCallback } from 'react'
 import { parseResolution, inlineSvgImages } from '../utils/svgUtils'
 
 /**
+ * Convert a title string to kebab-case for use in filenames
+ */
+function toKebabCase(title) {
+    if (!title) return 'thumbnail'
+    return title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        || 'thumbnail'
+}
+
+/**
  * Hook for exporting thumbnails as raster images or SVG
  */
-export function useExport(generateSvg, resolution, showToast) {
+export function useExport(generateSvg, resolution, showToast, title) {
     // Export as raster (JPG/PNG/WEBP)
     const exportRaster = useCallback(async (format = 'jpg') => {
         const [width, height] = parseResolution(resolution)
@@ -57,7 +69,7 @@ export function useExport(generateSvg, resolution, showToast) {
                 const downloadUrl = URL.createObjectURL(blob)
                 const a = document.createElement('a')
                 a.href = downloadUrl
-                a.download = `thumbnail-${Date.now()}.${extension}`
+                a.download = `${toKebabCase(title)}.${extension}`
                 a.click()
                 URL.revokeObjectURL(downloadUrl)
                 showToast(`${extension.toUpperCase()} exported successfully!`)
@@ -75,14 +87,58 @@ export function useExport(generateSvg, resolution, showToast) {
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
-        a.download = `thumbnail-${Date.now()}.svg`
+        a.download = `${toKebabCase(title)}.svg`
         a.click()
         URL.revokeObjectURL(url)
         showToast('SVG exported successfully!')
     }, [generateSvg, showToast])
 
+    // Copy preview to clipboard as PNG
+    const copyToClipboard = useCallback(async () => {
+        const [width, height] = parseResolution(resolution)
+        const svgString = generateSvg()
+
+        try {
+            const inlinedSvg = await inlineSvgImages(svgString)
+
+            const canvas = document.createElement('canvas')
+            canvas.width = width
+            canvas.height = height
+            const ctx = canvas.getContext('2d')
+            if (!ctx) throw new Error('Failed to get canvas context')
+
+            const img = new Image()
+            img.crossOrigin = 'anonymous'
+            const svgBlob = new Blob([inlinedSvg], { type: 'image/svg+xml;charset=utf-8' })
+            const url = URL.createObjectURL(svgBlob)
+
+            await new Promise((resolve, reject) => {
+                img.onload = resolve
+                img.onerror = () => reject(new Error('Failed to load SVG image'))
+                img.src = url
+            })
+
+            ctx.drawImage(img, 0, 0, width, height)
+            URL.revokeObjectURL(url)
+
+            const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'))
+            if (!blob) {
+                showToast('Failed to copy to clipboard.', 'error')
+                return
+            }
+            await navigator.clipboard.write([
+                new ClipboardItem({ 'image/png': blob })
+            ])
+            showToast('Copied to clipboard!')
+        } catch (err) {
+            console.error('Copy to clipboard failed:', err)
+            showToast('Failed to copy to clipboard.', 'error')
+        }
+    }, [resolution, generateSvg, showToast])
+
     return {
         exportRaster,
         exportSvg,
+        copyToClipboard,
     }
 }


### PR DESCRIPTION
This pull request adds a "Copy to clipboard" feature for the preview image and improves export file naming. The main changes include a new clipboard button in the UI, logic to copy the preview as a PNG image, and using kebab-case filenames based on the title for exports.

**Clipboard functionality:**

* Added a `copyToClipboard` function in `useExport` that copies the preview image as a PNG to the clipboard, handling SVG rendering and error cases.
* Introduced a "Copy to clipboard" button in the UI (`App.jsx`) that triggers the new clipboard functionality.
* Passed the new `copyToClipboard` method from `useExport` to the main app component.
* Added styles for `.btn-clipboard` to `App.css` to visually distinguish the new button.

**Export improvements:**

* Updated export file naming to use a kebab-case version of the title (or a default) for both raster and SVG exports, improving clarity and consistency. [[1]](diffhunk://#diff-01f3d260d3643595233186ea8def754ddd0d92e4dfc9b976d75e469070b2bdaaR4-R19) [[2]](diffhunk://#diff-01f3d260d3643595233186ea8def754ddd0d92e4dfc9b976d75e469070b2bdaaL60-R72)