### PR TITLE
fix(deps): bump brace-expansion to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Bumps `brace-expansion` to a patched version via `npm audit fix`. Lockfile-only change.

## Why

`npm audit` reported 1 moderate vulnerability:

> brace-expansion: Large numeric range defeats documented `max` DoS protection — GHSA-jxxr-4gwj-5jf2

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run build` passes
- Only `package-lock.json` changed
