### PR TITLE
fix(lint): resolve all eslint errors

### DIFF
--- a/cli/generate-thumbnail.mjs
+++ b/cli/generate-thumbnail.mjs
@@ -436,7 +436,7 @@ async function main() {
     const variant = args.variant || 'dark'
     const resolution = args.resolution || '1920x1080'
     const format = (args.format || 'png').toLowerCase()
-    const [width, height] = parseResolution(resolution)
+    const [width] = parseResolution(resolution)
 
     if (!['png', 'svg'].includes(format)) {
         console.error(`Unsupported format: ${format}. Use png or svg.`)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,4 +27,15 @@ export default [
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    files: ['cli/**/*.{js,mjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+    rules: {
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
 ]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,11 +111,11 @@ function TemplateRenderer({ templateId, values, selectedBackground, variant, res
   const TemplateComponent = templateComponents[templateId]
   const { generateSvg } = TemplateComponent({ values, selectedBackground, variant, resolution })
 
-  // Keep parent's ref in sync with the latest generateSvg
+  // Keep parent's ref in sync with the latest onGenerateSvg
   const callbackRef = useRef(onGenerateSvg)
   useEffect(() => {
     callbackRef.current = onGenerateSvg
-  })
+  }, [onGenerateSvg])
   useEffect(() => {
     callbackRef.current(generateSvg)
   }, [generateSvg])

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,7 +113,9 @@ function TemplateRenderer({ templateId, values, selectedBackground, variant, res
 
   // Keep parent's ref in sync with the latest generateSvg
   const callbackRef = useRef(onGenerateSvg)
-  callbackRef.current = onGenerateSvg
+  useEffect(() => {
+    callbackRef.current = onGenerateSvg
+  })
   useEffect(() => {
     callbackRef.current(generateSvg)
   }, [generateSvg])


### PR DESCRIPTION
## What

Resolves all 32 ESLint errors so `npm run lint` passes cleanly.

## Changes

- **`eslint.config.js`** — Add a config block giving `cli/**/*.{js,mjs}` Node globals (`globals.node`). The CLI script legitimately uses `console` and `process`, which were flagged as `no-undef` because only browser globals were configured.
- **`cli/generate-thumbnail.mjs`** — Drop the unused `height` from a destructure (`no-unused-vars`); only `width` is used.
- **`src/App.jsx`** — Move the `callbackRef.current` assignment out of render and into an effect (`react-hooks/refs`). Writing a ref during render can cause stale updates; the ref is now synced in an effect before the dependent effect runs.

## Verification

- `npm run lint` → **0 problems**
- `npm run build` passes

## Notes

Behavior is unchanged: `App.jsx` still calls `onGenerateSvg(generateSvg)` whenever `generateSvg` changes, using the latest callback.
