### PR TITLE
Refactor Dependabot configuration to simplify npm dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -10,10 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      npm-production-dependencies:
-        dependency-type: "production"
-      npm-development-dependencies:
-        dependency-type: "development"
+      npm-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request simplifies the Dependabot configuration by consolidating the dependency update groups for npm packages. Instead of maintaining separate groups for production and development dependencies, all npm dependencies are now managed under a single group.

Dependabot configuration changes:

* Merged the `npm-production-dependencies` and `npm-development-dependencies` groups into a single `npm-dependencies` group that matches all dependencies using a wildcard pattern. This simplifies dependency management and reduces configuration complexity.