### PR TITLE
feat: add wrapSpeakerNames utility and integrate into AzureDevelopers

### DIFF
--- a/src/templates/AzureDevelopersLiveTemplate.jsx
+++ b/src/templates/AzureDevelopersLiveTemplate.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { escapeXml, getTextMeasureContext, parseResolution, wrapTextToWidth } from '../utils/svgUtils'
 import { replaceTokens } from '../utils/svgTemplateProcessor'
+import { wrapSpeakerNames } from '../utils/speakerNameLines'
 
 const TEMPLATE_PATHS = {
     2: '/thumbnail-generator/templates/azure-developers-live/two-speakers.svg',
@@ -66,8 +67,7 @@ export function AzureDevelopersLiveTemplate({ values, resolution }) {
         const topicLines = wrapTextToWidth(topic.trim(), 1010, context, '700 140px "Segoe UI"').slice(0, 3)
         while (topicLines.length < 3) topicLines.push('')
         const names = speakerNames.split(/\s*[,+]\s*/).map(name => name.trim()).filter(Boolean)
-        const nameText = names.length ? `with ${names.join(' + ')}` : ''
-        const nameLines = wrapTextToWidth(nameText, 1025, context, '700 56px "Segoe UI"').slice(0, 2)
+        const nameLines = wrapSpeakerNames(names, 1025, context, '700 56px "Segoe UI"').slice(0, 2)
         while (nameLines.length < 2) nameLines.push('')
         const getSpeaker = index => speakers[index]?.dataUrl || speakers[index]?.url || ''
         const tokens = {

--- a/src/utils/speakerNameLines.js
+++ b/src/utils/speakerNameLines.js
@@ -1,0 +1,29 @@
+export function wrapSpeakerNames(names, maxWidth, context, font) {
+    if (!names.length) return []
+
+    if (!context || !font || !Number.isFinite(maxWidth) || maxWidth <= 0) {
+        return [`with ${names[0]}${names.length > 1 ? ' +' : ''}`, ...names.slice(1)]
+    }
+
+    context.font = font
+    const segments = names.map((name, index) => (
+        index === 0
+            ? `with ${name}${names.length > 1 ? ' +' : ''}`
+            : `${name}${index < names.length - 1 ? ' +' : ''}`
+    ))
+    const lines = []
+    let currentLine = ''
+
+    for (const segment of segments) {
+        const nextLine = currentLine ? `${currentLine} ${segment}` : segment
+        if (currentLine && context.measureText(nextLine).width > maxWidth) {
+            lines.push(currentLine)
+            currentLine = segment
+        } else {
+            currentLine = nextLine
+        }
+    }
+
+    if (currentLine) lines.push(currentLine)
+    return lines
+}

--- a/src/utils/speakerNameLines.test.js
+++ b/src/utils/speakerNameLines.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { wrapSpeakerNames } from './speakerNameLines'
+
+describe('wrapSpeakerNames', () => {
+    it('keeps a second speaker full name together after the plus separator', () => {
+        const context = {
+            font: '',
+            measureText: text => ({ width: text.length }),
+        }
+
+        expect(wrapSpeakerNames(['Abraham Lincoln', 'Fredo Corleone'], 30, context, '700 56px Segoe UI')).toEqual([
+            'with Abraham Lincoln +',
+            'Fredo Corleone',
+        ])
+    })
+})


### PR DESCRIPTION
This pull request improves how speaker names are displayed in the Azure Developers Live template by introducing a new utility for wrapping speaker names and updating the template to use it. The main goal is to ensure that speaker names are formatted more naturally, especially when there are multiple speakers.

**Speaker name formatting improvements:**

* Added a new utility function `wrapSpeakerNames` in `src/utils/speakerNameLines.js` to handle wrapping speaker names, ensuring that names are grouped logically and lines do not break awkwardly.
* Updated `AzureDevelopersLiveTemplate.jsx` to use `wrapSpeakerNames` instead of generic text wrapping for speaker names, improving the readability and appearance of the speaker line. [[1]](diffhunk://#diff-b8e1a2a333c4881c0b057d05d99cc4993b8686d428713c769de7ced65d473d5aR4) [[2]](diffhunk://#diff-b8e1a2a333c4881c0b057d05d99cc4993b8686d428713c769de7ced65d473d5aL69-R70)

**Testing:**

* Added a unit test for `wrapSpeakerNames` in `src/utils/speakerNameLines.test.js` to verify that it keeps a second speaker's full name together after the plus separator.