### PR TITLE
fix: update SVG handling in LogoArrayField

### DIFF
--- a/cli/generate-thumbnail.mjs
+++ b/cli/generate-thumbnail.mjs
@@ -325,7 +325,8 @@ function generateSvg({ title, subtitle, pill, logos, variant, resolution, bgData
 
     // Text width constraint
     const hasRightSideContent = logos.length > 0
-    const textRightBoundary = hasRightSideContent ? (width / 2) : (width - edgeMarginX)
+    // node-canvas measures Segoe UI slightly wider than the browser renderer.
+    const textRightBoundary = hasRightSideContent ? (width * 0.52) : (width - edgeMarginX)
     const textMaxWidth = Math.max(0, textRightBoundary - titleX)
 
     const titleLines = wrapTextToWidth(title, textMaxWidth, textCtx, titleFont)
@@ -374,7 +375,7 @@ function generateSvg({ title, subtitle, pill, logos, variant, resolution, bgData
         const logoSize = logoClipRadius * Math.SQRT2 * 0.98
         return `
   <g transform="translate(${x}, ${y})">
-    <circle cx="0" cy="0" r="${logoCircleRadius}" fill="white" filter="url(#${uniqueId}-shadow)"/>
+        <circle cx="0" cy="0" r="${logoCircleRadius}" fill="white"/>
     <clipPath id="${uniqueId}-logo-clip-${i}">
       <circle cx="0" cy="0" r="${logoClipRadius}"/>
     </clipPath>
@@ -382,12 +383,6 @@ function generateSvg({ title, subtitle, pill, logos, variant, resolution, bgData
   </g>`
     }).join('')}
 
-  <!-- Filters -->
-  <defs>
-    <filter id="${uniqueId}-shadow" x="-50%" y="-50%" width="200%" height="200%">
-      <feDropShadow dx="0" dy="2" stdDeviation="8" flood-opacity="0.15"/>
-    </filter>
-  </defs>
 </svg>`
 }
 

--- a/src/components/LogoArrayField.jsx
+++ b/src/components/LogoArrayField.jsx
@@ -35,12 +35,6 @@ export function LogoArrayField({
         const file = event.target.files?.[0]
         if (!file) return
 
-        if (/^image\/svg\+xml(?:;|$)/i.test(file.type) || /\.svg$/i.test(file.name)) {
-            showToast?.('SVG logos are not supported. Choose a raster image.', 'error')
-            event.target.value = ''
-            return
-        }
-
         if (value.length >= maxItems) {
             showToast?.(`Maximum ${maxItems} logos allowed`, 'error')
             return
@@ -160,7 +154,7 @@ export function LogoArrayField({
                             type="file"
                             ref={fileInputRef}
                             onChange={handleFileUpload}
-                            accept="image/png,image/jpeg,image/gif,image/webp,image/avif"
+                            accept="image/svg+xml,image/png,image/jpeg,image/gif,image/webp,image/avif"
                             className="visually-hidden"
                         />
                         <button

--- a/src/components/LogoArrayField.test.jsx
+++ b/src/components/LogoArrayField.test.jsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { LogoArrayField } from './LogoArrayField'
 
 describe('LogoArrayField', () => {
-    it('rejects SVG uploads', () => {
+    it('accepts SVG uploads', async () => {
         const onChange = vi.fn()
         const showToast = vi.fn()
         const { container } = render(
@@ -16,11 +16,15 @@ describe('LogoArrayField', () => {
             target: { files: [new File(['<svg />'], 'logo.svg', { type: 'image/svg+xml' })] },
         })
 
-        expect(onChange).not.toHaveBeenCalled()
-        expect(showToast).toHaveBeenCalledWith(
-            'SVG logos are not supported. Choose a raster image.',
-            'error'
-        )
-        expect(input).toHaveAttribute('accept', 'image/png,image/jpeg,image/gif,image/webp,image/avif')
+        await waitFor(() => expect(onChange).toHaveBeenCalledOnce())
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'logo.svg',
+                isUploaded: true,
+                dataUrl: expect.stringMatching(/^data:image\/svg\+xml;base64,/),
+            }),
+        ])
+        expect(showToast).not.toHaveBeenCalled()
+        expect(input).toHaveAttribute('accept', 'image/svg+xml,image/png,image/jpeg,image/gif,image/webp,image/avif')
     })
 })

--- a/src/templates/DotNetBlogTemplate.jsx
+++ b/src/templates/DotNetBlogTemplate.jsx
@@ -219,9 +219,6 @@ export function DotNetBlogTemplate({
         
         <!-- Filters and clip paths -->
         <defs>
-          <filter id="${uniqueId}-shadow" x="-50%" y="-50%" width="200%" height="200%">
-            <feDropShadow dx="0" dy="2" stdDeviation="8" flood-opacity="0.15"/>
-          </filter>
           <filter id="${uniqueId}-image-shadow" x="-50%" y="-50%" width="200%" height="200%">
             <feDropShadow dx="-6" dy="-6" stdDeviation="25" flood-opacity="0.3"/>
           </filter>

--- a/src/templates/DotNetBlogTemplate.jsx
+++ b/src/templates/DotNetBlogTemplate.jsx
@@ -172,7 +172,7 @@ export function DotNetBlogTemplate({
       const logoSize = logoClipRadius * Math.SQRT2 * 0.98
       return `
             <g transform="translate(${x}, ${y})">
-              <circle cx="0" cy="0" r="${logoCircleRadius}" fill="white" filter="url(#${uniqueId}-shadow)"/>
+              <circle cx="0" cy="0" r="${logoCircleRadius}" fill="white"/>
               <clipPath id="${uniqueId}-logo-clip-${i}">
                 <circle cx="0" cy="0" r="${logoClipRadius}"/>
               </clipPath>

--- a/src/utils/svgUtils.js
+++ b/src/utils/svgUtils.js
@@ -87,7 +87,7 @@ export function parseResolution(resolution) {
 }
 
 /**
- * Convert a Blob to a data URL
+ * Convert a Blob to a data URL for self-contained SVG exports.
  */
 export function blobToDataUrl(blob) {
     return new Promise((resolve, reject) => {
@@ -96,94 +96,6 @@ export function blobToDataUrl(blob) {
         reader.onload = () => resolve(reader.result)
         reader.readAsDataURL(blob)
     })
-}
-
-/**
- * Replace an image element with a namespaced inline SVG document. SVG data URLs
- * nested in image elements are not consistently supported by image viewers.
- */
-async function inlineSvgBlob(blob, imageElement, imageIndex) {
-    const sourceDocument = new DOMParser().parseFromString(await blob.text(), 'image/svg+xml')
-    const sourceSvg = sourceDocument.documentElement
-    if (!sourceSvg || sourceSvg.nodeName.toLowerCase() !== 'svg' || sourceDocument.querySelector('parsererror')) {
-        throw new Error('Failed to parse SVG image')
-    }
-
-    namespaceSvgIds(sourceSvg, `embedded-svg-${imageIndex}`)
-    copyImageLayout(imageElement, sourceSvg)
-    imageElement.replaceWith(sourceSvg)
-}
-
-function namespaceSvgIds(svg, prefix) {
-    const ids = new Map()
-    const elements = [svg, ...svg.querySelectorAll('*')]
-    elements.filter((element) => element.hasAttribute('id')).forEach((element) => {
-        const originalId = element.getAttribute('id')
-        const namespacedId = `${prefix}-${originalId}`
-        ids.set(originalId, namespacedId)
-        element.setAttribute('id', namespacedId)
-    })
-
-    if (ids.size === 0) return
-
-    const replaceReferences = (value) => value
-        .replace(/url\(\s*(?:(["'])#([^"']+)\1|#([^) \t\r\n]+))\s*\)/gi, (match, quote, quotedId, unquotedId) => {
-            const id = quotedId || unquotedId
-            const namespacedId = ids.get(id)
-            return namespacedId ? `url(${quote || ''}#${namespacedId}${quote || ''})` : match
-        })
-        .replace(/^#(.+)$/, (match, id) => `#${ids.get(id) || id}`)
-
-    elements.forEach((element) => {
-        Array.from(element.attributes).forEach((attribute) => {
-            const updatedValue = replaceReferences(attribute.value)
-            if (updatedValue !== attribute.value) {
-                element.setAttribute(attribute.name, updatedValue)
-            }
-        })
-        if (element.nodeName.toLowerCase() === 'style') {
-            element.textContent = replaceCssReferences(element.textContent || '', ids, replaceReferences)
-        }
-    })
-}
-
-function replaceCssReferences(css, ids, replaceReferences) {
-    const styleSheet = new CSSStyleSheet()
-    styleSheet.replaceSync(css)
-
-    const updateRules = (rules) => {
-        Array.from(rules).forEach((rule) => {
-            if (rule.selectorText) {
-                rule.selectorText = rule.selectorText.replace(/#([\w-]+)/g, (match, id) => (
-                    ids.has(id) ? `#${ids.get(id)}` : match
-                ))
-            }
-            if (rule.style) {
-                Array.from(rule.style).forEach((property) => {
-                    const value = rule.style.getPropertyValue(property)
-                    const updatedValue = replaceReferences(value)
-                    if (updatedValue !== value) {
-                        rule.style.setProperty(property, updatedValue, rule.style.getPropertyPriority(property))
-                    }
-                })
-            }
-            if (rule.cssRules) updateRules(rule.cssRules)
-        })
-    }
-
-    updateRules(styleSheet.cssRules)
-    return Array.from(styleSheet.cssRules, (rule) => rule.cssText).join('\n')
-}
-
-function copyImageLayout(imageElement, sourceSvg) {
-    for (const attribute of Array.from(imageElement.attributes)) {
-        if (attribute.name === 'href' || attribute.name === 'xlink:href') continue
-        sourceSvg.setAttribute(attribute.name, attribute.value)
-    }
-}
-
-function isSvgBlob(blob) {
-    return /^image\/svg\+xml(?:;|$)/i.test(blob.type)
 }
 
 /**
@@ -223,7 +135,7 @@ export async function inlineSvgImages(svgString) {
     }
 
     const images = Array.from(svg.querySelectorAll('image'))
-    await Promise.all(images.map(async (img, index) => {
+    await Promise.all(images.map(async (img) => {
         const href = img.getAttribute('href') || img.getAttribute('xlink:href')
         if (!href || href.startsWith('data:')) return
 
@@ -245,10 +157,6 @@ export async function inlineSvgImages(svgString) {
                 return
             }
             const blob = await response.blob()
-            if (isSvgBlob(blob)) {
-                await inlineSvgBlob(blob, img, index)
-                return
-            }
             const dataUrl = await blobToDataUrl(blob)
             img.setAttribute('href', dataUrl)
             img.setAttribute('xlink:href', dataUrl)

--- a/src/utils/svgUtils.test.js
+++ b/src/utils/svgUtils.test.js
@@ -61,22 +61,10 @@ describe('inlineSvgImages', () => {
         expect(image?.getAttribute('href')).toMatch(/^data:image\/png;base64,/)
         expect(image?.getAttribute('xlink:href')).toMatch(/^data:image\/png;base64,/)
     })
-    it('inlines SVG image assets with namespaced references', async () => {
+    it('embeds SVG image assets as data URLs without nesting SVG documents', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
             ok: true,
-            blob: vi.fn().mockResolvedValue({
-                type: 'image/svg+xml',
-                text: vi.fn().mockResolvedValue(`
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-                        <defs><linearGradient id="gradient"><stop /></linearGradient></defs>
-                        <style>
-                            #shape { fill: url("#gradient"); }
-                        </style>
-                        <rect id="shape" fill="url('#gradient')" />
-                        <circle fill="url(#gradient)" />
-                    </svg>
-                `),
-            }),
+            blob: vi.fn().mockResolvedValue(new File(['<svg xmlns="http://www.w3.org/2000/svg"/>'], 'logo.svg', { type: 'image/svg+xml' })),
         }))
 
         const result = await inlineSvgImages(`
@@ -86,14 +74,10 @@ describe('inlineSvgImages', () => {
         `)
 
         const document = new DOMParser().parseFromString(result, 'image/svg+xml')
-        const embeddedSvg = document.querySelector('svg > svg')
-        expect(document.querySelector('image')).toBeNull()
-        expect(embeddedSvg?.getAttribute('x')).toBe('10')
-        expect(embeddedSvg?.getAttribute('y')).toBe('20')
-        expect(embeddedSvg?.querySelector('linearGradient')?.getAttribute('id')).toBe('embedded-svg-0-gradient')
-        expect(embeddedSvg?.querySelector('rect')?.getAttribute('fill')).toBe("url('#embedded-svg-0-gradient')")
-        expect(embeddedSvg?.querySelector('circle')?.getAttribute('fill')).toBe('url(#embedded-svg-0-gradient)')
-        expect(embeddedSvg?.querySelector('style')?.textContent).toContain('#embedded-svg-0-shape')
-        expect(embeddedSvg?.querySelector('style')?.textContent).toContain('url("#embedded-svg-0-gradient")')
+        const image = document.querySelector('image')
+        expect(image?.getAttribute('x')).toBe('10')
+        expect(image?.getAttribute('y')).toBe('20')
+        expect(image?.getAttribute('href')).toMatch(/^data:image\/svg\+xml;base64,/)
+        expect(image?.getAttribute('xlink:href')).toMatch(/^data:image\/svg\+xml;base64,/)
     })
 })


### PR DESCRIPTION
This pull request updates SVG logo support throughout the app, allowing users to upload SVG logos and ensuring they are handled as data URLs rather than inlined SVG elements. It also removes the SVG logo drop-shadow filter from the generated SVG output. The changes simplify SVG handling, improve compatibility, and adjust tests to match the new behavior.

**SVG Logo Upload and Handling:**
* SVG logos are now accepted in the `LogoArrayField` component, and the file input `accept` attribute includes `image/svg+xml`. The previous restriction and error message for SVG uploads have been removed. [[1]](diffhunk://#diff-36b991dfff76c6cf4dc4fc4bd02e16601e120b515f0ffb05d282d5af70db4664L38-L43) [[2]](diffhunk://#diff-36b991dfff76c6cf4dc4fc4bd02e16601e120b515f0ffb05d282d5af70db4664L163-R157)
* The test for SVG uploads in `LogoArrayField.test.jsx` is updated to expect SVG files to be accepted and processed, rather than rejected. [[1]](diffhunk://#diff-0e445a142458be6ab3afd1bdcff7f02f5fec100add08ce56149466af4f80ef1eL2-R7) [[2]](diffhunk://#diff-0e445a142458be6ab3afd1bdcff7f02f5fec100add08ce56149466af4f80ef1eL19-R28)

**SVG Image Embedding and Export:**
* The SVG image inlining logic in `svgUtils.js` is simplified: SVG images are now always embedded as data URLs in `<image>` elements, rather than inlining the SVG markup and namespacing IDs. [[1]](diffhunk://#diff-1f6e985a170265257b6f5d50ba1391da54c385e58f170028aabe925b97ceaca7L101-L188) [[2]](diffhunk://#diff-1f6e985a170265257b6f5d50ba1391da54c385e58f170028aabe925b97ceaca7L226-R138) [[3]](diffhunk://#diff-1f6e985a170265257b6f5d50ba1391da54c385e58f170028aabe925b97ceaca7L248-L251)
* Corresponding tests for SVG image embedding are updated to expect data URL embedding instead of nested SVG elements. [[1]](diffhunk://#diff-0dd02cd4f2c30a96800392d659f3cc186bf32d85234d4baf7257aaf2d4f81631L64-R67) [[2]](diffhunk://#diff-0dd02cd4f2c30a96800392d659f3cc186bf32d85234d4baf7257aaf2d4f81631L89-R81)

**SVG Output Appearance:**
* The drop-shadow filter for logo circles in generated SVGs (in both `generate-thumbnail.mjs` and `DotNetBlogTemplate.jsx`) is removed, resulting in a simpler appearance for logo backgrounds. [[1]](diffhunk://#diff-80e7f9618ae44892c163269ab4d5e0b673aef6ce303149689ce2348f6b02ae56L377-L390) [[2]](diffhunk://#diff-a7c3608eecd4e6d3681ff0387b41eaed3aea5ed26becdd47f973e6c53f5cd131L175-R175)

**Minor Rendering Adjustment:**
* The text width constraint in `generate-thumbnail.mjs` is slightly increased when logos are present, to better match browser rendering.