### PR TITLE
Preserve repeated spaces when wrapping titles and topics

### DIFF
--- a/src/utils/svgTemplateProcessor.js
+++ b/src/utils/svgTemplateProcessor.js
@@ -52,27 +52,33 @@ export function replaceTokens(svgContent, tokens) {
 export function wrapTopicText(topic, maxCharsPerLine = 25, maxLines = 3) {
     if (!topic) return ['', '', ''];
 
-    const words = topic.split(' ');
+    const tokens = topic.trim().match(/\s+|[^\s]+/g) || [];
     const lines = [];
     let currentLine = '';
 
-    for (const [index, word] of words.entries()) {
-        if (currentLine.length + word.length + 1 <= maxCharsPerLine) {
-            currentLine = currentLine ? `${currentLine} ${word}` : word;
+    for (const [index, token] of tokens.entries()) {
+        if (/^\s+$/.test(token)) {
+            currentLine += token;
+            continue;
+        }
+
+        const nextLine = currentLine + token;
+        if (nextLine.length <= maxCharsPerLine || !currentLine.trim()) {
+            currentLine = nextLine;
         } else {
-            if (currentLine) lines.push(currentLine);
-            currentLine = word;
+            if (currentLine.trim()) lines.push(currentLine.trimEnd());
+            currentLine = token;
             if (lines.length >= maxLines - 1) {
                 // Last line - add remaining words
-                const remainingWords = words.slice(index);
-                lines.push(remainingWords.join(' '));
+                const remainingText = tokens.slice(index).join('').trim();
+                lines.push(currentLine + remainingText.slice(token.length));
                 break;
             }
         }
     }
 
-    if (currentLine && lines.length < maxLines) {
-        lines.push(currentLine);
+    if (currentLine.trim() && lines.length < maxLines) {
+        lines.push(currentLine.trimEnd());
     }
 
     // Pad to maxLines

--- a/src/utils/svgTemplateProcessor.js
+++ b/src/utils/svgTemplateProcessor.js
@@ -66,6 +66,11 @@ export function wrapTopicText(topic, maxCharsPerLine = 25, maxLines = 3) {
         if (nextLine.length <= maxCharsPerLine || !currentLine.trim()) {
             currentLine = nextLine;
         } else {
+            if (lines.length >= maxLines - 1) {
+                const remainingText = tokens.slice(index).join('').trim();
+                lines.push(currentLine + remainingText);
+                break;
+            }
             if (currentLine.trim()) lines.push(currentLine.trimEnd());
             currentLine = token;
             if (lines.length >= maxLines - 1) {

--- a/src/utils/svgTemplateProcessor.test.js
+++ b/src/utils/svgTemplateProcessor.test.js
@@ -32,4 +32,9 @@ describe('wrapTopicText', () => {
         const joined = lines.join(' ').trimEnd()
         expect(joined).toBe('the quick brown fox the the lazy dog the end')
     })
+
+    it('counts repeated spaces when deciding where the topic wraps', () => {
+        expect(wrapTopicText('This is an            exciting post', 23, 3))
+            .toEqual(['This is an', 'exciting post', ''])
+    })
 })

--- a/src/utils/svgTemplateProcessor.test.js
+++ b/src/utils/svgTemplateProcessor.test.js
@@ -37,4 +37,8 @@ describe('wrapTopicText', () => {
         expect(wrapTopicText('This is an            exciting post', 23, 3))
             .toEqual(['This is an', 'exciting post', ''])
     })
+
+    it('does not exceed maxLines when the limit is one line', () => {
+        expect(wrapTopicText('a b', 1, 1)).toEqual(['a b'])
+    })
 })

--- a/src/utils/svgUtils.js
+++ b/src/utils/svgUtils.js
@@ -20,20 +20,25 @@ export function escapeXml(text) {
  */
 export function wrapText(text, maxChars) {
     if (!text) return []
-    const words = text.split(' ')
     const lines = []
-    let currentLine = ''
 
-    words.forEach(word => {
-        if ((currentLine + ' ' + word).trim().length <= maxChars) {
-            currentLine = (currentLine + ' ' + word).trim()
-        } else {
-            if (currentLine) lines.push(currentLine)
-            currentLine = word
-        }
+    text.split(/\r?\n/).forEach((paragraph) => {
+        const tokens = paragraph.match(/\s+|[^\s]+/g) || []
+        let currentLine = ''
+
+        tokens.forEach(token => {
+            const next = currentLine + token
+            if (/^\s+$/.test(token) || next.length <= maxChars) {
+                currentLine = next
+            } else {
+                if (currentLine.trim()) lines.push(currentLine.trimEnd())
+                currentLine = token.trimStart()
+            }
+        })
+
+        if (currentLine.trim()) lines.push(currentLine.trimEnd())
     })
 
-    if (currentLine) lines.push(currentLine)
     return lines
 }
 
@@ -47,22 +52,30 @@ export function wrapTextToWidth(text, maxWidth, ctx, font) {
     }
 
     ctx.font = font
-    const words = text.split(/\s+/).filter(Boolean)
     const lines = []
-    let current = ''
 
-    for (const word of words) {
-        const next = current ? `${current} ${word}` : word
-        if (ctx.measureText(next).width <= maxWidth) {
-            current = next
-            continue
+    text.split(/\r?\n/).forEach((paragraph) => {
+        const tokens = paragraph.match(/\s+|[^\s]+/g) || []
+        let current = ''
+
+        for (const token of tokens) {
+            const next = current + token
+            if (/^\s+$/.test(token)) {
+                current = next
+                continue
+            }
+            if (ctx.measureText(next).width <= maxWidth) {
+                current = next
+                continue
+            }
+
+            if (current.trim()) lines.push(current.trimEnd())
+            current = token.trimStart()
         }
 
-        if (current) lines.push(current)
-        current = word
-    }
+        if (current.trim()) lines.push(current.trimEnd())
+    })
 
-    if (current) lines.push(current)
     return lines
 }
 

--- a/src/utils/svgUtils.test.js
+++ b/src/utils/svgUtils.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { escapeXml, inlineSvgImages, parseResolution, wrapText } from './svgUtils'
+import { escapeXml, inlineSvgImages, parseResolution, wrapText, wrapTextToWidth } from './svgUtils'
 
 afterEach(() => {
     vi.unstubAllGlobals()
@@ -25,6 +25,15 @@ describe('wrapText', () => {
     it('returns an empty array for empty input', () => {
         expect(wrapText('', 10)).toEqual([])
     })
+
+    it('preserves explicit line breaks', () => {
+        expect(wrapText('first line\nsecond line', 20)).toEqual(['first line', 'second line'])
+    })
+
+    it('counts repeated spaces when wrapping by character limit', () => {
+        expect(wrapText('This is an            exciting post', 23))
+            .toEqual(['This is an', 'exciting post'])
+    })
 })
 
 describe('parseResolution', () => {
@@ -35,6 +44,22 @@ describe('parseResolution', () => {
     it('falls back to 1920x1080 for invalid input', () => {
         expect(parseResolution('garbage')).toEqual([1920, 1080])
         expect(parseResolution(undefined)).toEqual([1920, 1080])
+    })
+})
+
+describe('wrapTextToWidth', () => {
+    it('preserves explicit line breaks while wrapping each line', () => {
+        const ctx = { measureText: (text) => ({ width: text.length }) }
+
+        expect(wrapTextToWidth('first line\nsecond line', 20, ctx, '16px sans-serif'))
+            .toEqual(['first line', 'second line'])
+    })
+
+    it('uses repeated spaces when deciding where to wrap', () => {
+        const ctx = { measureText: (text) => ({ width: text.length }) }
+
+        expect(wrapTextToWidth('This is an            exciting post', 23, ctx, '16px sans-serif'))
+            .toEqual(['This is an', 'exciting post'])
     })
 })
 


### PR DESCRIPTION
## Summary

- Preserve repeated spaces when wrapping title and topic text.
- Apply the behavior to the shared pixel-width wrapper used by .NET Blog, On .NET Live, and Azure Developers Live.
- Update the Community Standup topic wrapper to count repeated spaces as well.

## Validation

- `npm.cmd test` (27 tests passed)
- `npm.cmd run lint`