### PR TITLE
Fix repeated-space title line breaks

### DIFF
--- a/src/utils/svgTemplateProcessor.js
+++ b/src/utils/svgTemplateProcessor.js
@@ -57,7 +57,7 @@ export function wrapTopicText(topic, maxCharsPerLine = 25, maxLines = 3) {
     let currentLine = '';
 
     for (const [index, token] of tokens.entries()) {
-        if (/^\s{2,}$/.test(token)) {
+        if (/ {2,}/.test(token)) {
             if (lines.length >= maxLines - 1) {
                 const remainingText = tokens.slice(index + 1).join('').trim();
                 currentLine = `${currentLine.trimEnd()} ${remainingText}`.trim();

--- a/src/utils/svgTemplateProcessor.js
+++ b/src/utils/svgTemplateProcessor.js
@@ -57,6 +57,17 @@ export function wrapTopicText(topic, maxCharsPerLine = 25, maxLines = 3) {
     let currentLine = '';
 
     for (const [index, token] of tokens.entries()) {
+        if (/^\s{2,}$/.test(token)) {
+            if (lines.length >= maxLines - 1) {
+                const remainingText = tokens.slice(index + 1).join('').trim();
+                currentLine = `${currentLine.trimEnd()} ${remainingText}`.trim();
+                break;
+            }
+            if (currentLine.trim()) lines.push(currentLine.trimEnd());
+            currentLine = '';
+            continue;
+        }
+
         if (/^\s+$/.test(token)) {
             currentLine += token;
             continue;

--- a/src/utils/svgTemplateProcessor.test.js
+++ b/src/utils/svgTemplateProcessor.test.js
@@ -33,12 +33,13 @@ describe('wrapTopicText', () => {
         expect(joined).toBe('the quick brown fox the the lazy dog the end')
     })
 
-    it('counts repeated spaces when deciding where the topic wraps', () => {
-        expect(wrapTopicText('This is an            exciting post', 23, 3))
+    it('uses repeated spaces as an explicit wrapping point', () => {
+        expect(wrapTopicText('This is an  exciting post', 100, 3))
             .toEqual(['This is an', 'exciting post', ''])
     })
 
     it('does not exceed maxLines when the limit is one line', () => {
         expect(wrapTopicText('a b', 1, 1)).toEqual(['a b'])
+        expect(wrapTopicText('a  b', 100, 1)).toEqual(['a b'])
     })
 })

--- a/src/utils/svgUtils.js
+++ b/src/utils/svgUtils.js
@@ -27,6 +27,12 @@ export function wrapText(text, maxChars) {
         let currentLine = ''
 
         tokens.forEach(token => {
+            if (/^\s{2,}$/.test(token)) {
+                if (currentLine.trim()) lines.push(currentLine.trimEnd())
+                currentLine = ''
+                return
+            }
+
             const next = currentLine + token
             if (/^\s+$/.test(token) || next.length <= maxChars) {
                 currentLine = next
@@ -59,6 +65,12 @@ export function wrapTextToWidth(text, maxWidth, ctx, font) {
         let current = ''
 
         for (const token of tokens) {
+            if (/^\s{2,}$/.test(token)) {
+                if (current.trim()) lines.push(current.trimEnd())
+                current = ''
+                continue
+            }
+
             const next = current + token
             if (/^\s+$/.test(token)) {
                 current = next

--- a/src/utils/svgUtils.js
+++ b/src/utils/svgUtils.js
@@ -27,7 +27,7 @@ export function wrapText(text, maxChars) {
         let currentLine = ''
 
         tokens.forEach(token => {
-            if (/^\s{2,}$/.test(token)) {
+            if (/ {2,}/.test(token)) {
                 if (currentLine.trim()) lines.push(currentLine.trimEnd())
                 currentLine = ''
                 return

--- a/src/utils/svgUtils.test.js
+++ b/src/utils/svgUtils.test.js
@@ -30,8 +30,8 @@ describe('wrapText', () => {
         expect(wrapText('first line\nsecond line', 20)).toEqual(['first line', 'second line'])
     })
 
-    it('counts repeated spaces when wrapping by character limit', () => {
-        expect(wrapText('This is an            exciting post', 23))
+    it('uses repeated spaces as an explicit wrapping point', () => {
+        expect(wrapText('This is an  exciting post', 100))
             .toEqual(['This is an', 'exciting post'])
     })
 })
@@ -55,10 +55,10 @@ describe('wrapTextToWidth', () => {
             .toEqual(['first line', 'second line'])
     })
 
-    it('uses repeated spaces when deciding where to wrap', () => {
+    it('uses repeated spaces as an explicit wrapping point', () => {
         const ctx = { measureText: (text) => ({ width: text.length }) }
 
-        expect(wrapTextToWidth('This is an            exciting post', 23, ctx, '16px sans-serif'))
+        expect(wrapTextToWidth('This is an  exciting post', 100, ctx, '16px sans-serif'))
             .toEqual(['This is an', 'exciting post'])
     })
 })


### PR DESCRIPTION
## Summary

- Treat two or more spaces as an explicit line-break marker in wrapped title and topic fields.
- Keep the intended break stable when .NET Blog auto-sizes title text.
- Preserve Community Standup's maximum line count.

## Validation

- `npm.cmd test` (29 tests passed)
- `npm.cmd run lint`
- Verified with the real canvas font measurement across all .NET Blog title font sizes.